### PR TITLE
Fix tracking toggle bug for containers in tracked projects

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -40,12 +40,12 @@ func New(cfg *Config, cfgPath string) (*Agent, error) {
 	}
 
 	// Load persisted tracking state. Non-fatal if it fails.
-	containers, projects, err := store.LoadTracking(context.Background())
+	tracked, err := store.LoadTracking(context.Background())
 	if err != nil {
 		slog.Warn("failed to load tracking state", "error", err)
-	} else if len(containers) > 0 || len(projects) > 0 {
-		docker.LoadTrackingState(containers, projects)
-		slog.Info("loaded tracking state", "containers", len(containers), "projects", len(projects))
+	} else if len(tracked) > 0 {
+		docker.LoadTrackingState(tracked)
+		slog.Info("loaded tracking state", "containers", len(tracked))
 	}
 
 	hub := NewHub()

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -110,11 +110,10 @@ func TestApplyConfigUpdatesFields(t *testing.T) {
 	defer store.Close()
 
 	docker := &DockerCollector{
-		include:           []string{"web-*"},
-		exclude:           nil,
-		prevCPU:           make(map[string]cpuPrev),
-		tracked:         make(map[string]bool),
-		trackedProjects: make(map[string]bool),
+		include: []string{"web-*"},
+		exclude: nil,
+		prevCPU: make(map[string]cpuPrev),
+		tracked: make(map[string]bool),
 	}
 
 	hub := NewHub()
@@ -175,9 +174,8 @@ func TestApplyConfigRebuildsAlerter(t *testing.T) {
 	defer store.Close()
 
 	docker := &DockerCollector{
-		prevCPU:           make(map[string]cpuPrev),
-		tracked:         make(map[string]bool),
-		trackedProjects: make(map[string]bool),
+		prevCPU: make(map[string]cpuPrev),
+		tracked: make(map[string]bool),
 	}
 
 	hub := NewHub()

--- a/internal/agent/alert_integration_test.go
+++ b/internal/agent/alert_integration_test.go
@@ -36,9 +36,8 @@ func newAlertPipeline(t *testing.T, alerts map[string]AlertConfig) *alertPipelin
 
 	hub := NewHub()
 	dc := &DockerCollector{
-		prevCPU:         make(map[string]cpuPrev),
-		tracked:         map[string]bool{"web": true, "api": true, "db": true},
-		trackedProjects: make(map[string]bool),
+		prevCPU: make(map[string]cpuPrev),
+		tracked: map[string]bool{"web": true, "api": true, "db": true},
 	}
 
 	ew := &EventWatcher{

--- a/internal/agent/events_test.go
+++ b/internal/agent/events_test.go
@@ -45,9 +45,8 @@ func testEventWatcher(t *testing.T, include, exclude []string) (*EventWatcher, *
 	dc := &DockerCollector{
 		include:         include,
 		exclude:         exclude,
-		prevCPU:         make(map[string]cpuPrev),
-		tracked:         map[string]bool{"web": true},
-		trackedProjects: make(map[string]bool),
+		prevCPU: make(map[string]cpuPrev),
+		tracked: map[string]bool{"web": true},
 	}
 	hub := NewHub()
 

--- a/internal/agent/store_queries_test.go
+++ b/internal/agent/store_queries_test.go
@@ -633,20 +633,17 @@ func TestSaveAndLoadTracking(t *testing.T) {
 	ctx := context.Background()
 
 	// Save tracking state.
-	if err := s.SaveTracking(ctx, []string{"web", "api"}, []string{"myapp"}); err != nil {
+	if err := s.SaveTracking(ctx, []string{"web", "api"}); err != nil {
 		t.Fatal(err)
 	}
 
 	// Load it back.
-	containers, projects, err := s.LoadTracking(ctx)
+	containers, err := s.LoadTracking(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(containers) != 2 {
 		t.Errorf("containers = %d, want 2", len(containers))
-	}
-	if len(projects) != 1 || projects[0] != "myapp" {
-		t.Errorf("projects = %v, want [myapp]", projects)
 	}
 }
 
@@ -655,22 +652,19 @@ func TestSaveTrackingOverwrites(t *testing.T) {
 	ctx := context.Background()
 
 	// Save initial state.
-	s.SaveTracking(ctx, []string{"web", "api"}, []string{"myapp"})
+	s.SaveTracking(ctx, []string{"web", "api"})
 
 	// Overwrite with different state.
-	if err := s.SaveTracking(ctx, []string{"db"}, nil); err != nil {
+	if err := s.SaveTracking(ctx, []string{"db"}); err != nil {
 		t.Fatal(err)
 	}
 
-	containers, projects, err := s.LoadTracking(ctx)
+	containers, err := s.LoadTracking(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(containers) != 1 || containers[0] != "db" {
 		t.Errorf("containers = %v, want [db]", containers)
-	}
-	if len(projects) != 0 {
-		t.Errorf("projects = %v, want []", projects)
 	}
 }
 
@@ -678,15 +672,12 @@ func TestLoadTrackingEmpty(t *testing.T) {
 	s := testStore(t)
 	ctx := context.Background()
 
-	containers, projects, err := s.LoadTracking(ctx)
+	containers, err := s.LoadTracking(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(containers) != 0 {
 		t.Errorf("containers = %v, want empty", containers)
-	}
-	if len(projects) != 0 {
-		t.Errorf("projects = %v, want empty", projects)
 	}
 }
 


### PR DESCRIPTION
Project-level tracking was stored separately from per-container tracking, using an OR-based lookup. This made it impossible to untrack a single container within a tracked project — the project match always won.

Replace the two-map model (tracked + trackedProjects) with per-container tracking only. Toggling a project now expands to toggle all its known containers individually.