### PR TITLE
Add server-side log search, SSH compression, and graph loading states

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,6 @@ When connected to multiple servers, use `Tab` to focus the servers panel, then `
 | `Enter` | Expand log entry |
 | `s` | Cycle stream filter (all/stdout/stderr) |
 | `f` | Open log filter |
-| `g` | Cycle project filter |
 | `Esc` | Back to dashboard |
 
 ## Security
@@ -437,7 +436,7 @@ When connected to multiple servers, use `Tab` to focus the servers panel, then `
 
 **Config file:** The agent config contains SMTP credentials and webhook URLs. Permissions should be `0600` owned by the user running the agent.
 
-**No exposed ports:** Tori does not listen on any network port. All client communication goes through SSH to the Unix socket. There is no HTTP server, no API endpoint, nothing to expose or firewall.
+**No exposed ports:** Tori does not listen on any network port. All client communication goes through SSH to the Unix socket. There is no HTTP server, no API endpoint, nothing to expose or firewall. SSH compression is enabled by default on all tunnels to reduce bandwidth for metrics and log traffic.
 
 **Log contents:** Tori stores container logs in SQLite. These may contain sensitive application data (tokens, user info, errors with PII). The database file at `/var/lib/tori/tori.db` should have restrictive permissions and the retention policy should be set appropriately.
 

--- a/internal/agent/socket.go
+++ b/internal/agent/socket.go
@@ -545,6 +545,22 @@ func (c *connState) queryLogs(env *protocol.Envelope) {
 	}
 
 	resp := protocol.QueryLogsResp{Entries: convertLogEntries(entries)}
+
+	// Count total logs in scope (excluding search/stream/limit) so the TUI
+	// can show "X of Y". Non-fatal — proceed with 0 if it fails.
+	countFilter := LogFilter{
+		Start:        filter.Start,
+		End:          filter.End,
+		ContainerIDs: filter.ContainerIDs,
+		Project:      filter.Project,
+		Service:      filter.Service,
+	}
+	if total, err := c.ss.store.CountLogs(c.ctx, countFilter); err != nil {
+		slog.Warn("count logs", "error", err)
+	} else {
+		resp.Total = total
+	}
+
 	c.sendResponse(env.ID, &resp)
 }
 

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -137,6 +137,7 @@ type QueryLogsReq struct {
 // QueryLogsResp is the response for TypeQueryLogs.
 type QueryLogsResp struct {
 	Entries []LogEntryMsg `msgpack:"entries"`
+	Total   int           `msgpack:"total,omitempty"`
 }
 
 // QueryAlertsReq is the body for TypeQueryAlerts.

--- a/internal/tui/client.go
+++ b/internal/tui/client.go
@@ -254,17 +254,17 @@ func (c *Client) QueryMetrics(ctx context.Context, req *protocol.QueryMetricsReq
 	return &r, nil
 }
 
-// QueryLogs returns historical log entries.
-func (c *Client) QueryLogs(ctx context.Context, req *protocol.QueryLogsReq) ([]protocol.LogEntryMsg, error) {
+// QueryLogs returns historical log entries and the total count of logs in scope.
+func (c *Client) QueryLogs(ctx context.Context, req *protocol.QueryLogsReq) ([]protocol.LogEntryMsg, int, error) {
 	resp, err := c.Request(ctx, protocol.TypeQueryLogs, req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	var r protocol.QueryLogsResp
 	if err := protocol.DecodeBody(resp.Body, &r); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return r.Entries, nil
+	return r.Entries, r.Total, nil
 }
 
 // QueryAlerts returns historical alerts.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -160,7 +160,7 @@ func renderDashboard(a *App, s *Session, width, height int) string {
 		leftW := hostW * 65 / 100
 		rightW := hostW - leftW
 
-		cpuPanel := renderCPUPanel(cpuHistory, s.Host, RenderContext{Width: leftW, Height: cpuH, Theme: theme, WindowLabel: windowLabel, WindowSec: a.windowSeconds(), SpinnerFrame: a.spinnerFrame})
+		cpuPanel := renderCPUPanel(cpuHistory, s.Host, RenderContext{Width: leftW, Height: cpuH, Theme: theme, WindowLabel: windowLabel, WindowSec: a.windowSeconds(), SpinnerFrame: a.spinnerFrame, Loading: s.BackfillPending})
 		// Split right column: memory on top, disks on bottom.
 		diskH := len(s.Disks)*3 + 2 // 3 lines per disk (divider + used + free) + borders
 		if s.Host != nil && s.Host.SwapTotal > 0 {
@@ -178,7 +178,7 @@ func renderDashboard(a *App, s *Session, width, height int) string {
 			diskH = cpuH - memH
 		}
 
-		memPanel := renderMemPanel(s.Host, s.HostMemUsedHistory.Data(), RenderContext{Width: rightW, Height: memH, Theme: theme, WindowLabel: windowLabel, WindowSec: a.windowSeconds(), SpinnerFrame: a.spinnerFrame})
+		memPanel := renderMemPanel(s.Host, s.HostMemUsedHistory.Data(), RenderContext{Width: rightW, Height: memH, Theme: theme, WindowLabel: windowLabel, WindowSec: a.windowSeconds(), SpinnerFrame: a.spinnerFrame, Loading: s.BackfillPending})
 		var swapTotal, swapUsed uint64
 		if s.Host != nil {
 			swapTotal, swapUsed = s.Host.SwapTotal, s.Host.SwapUsed
@@ -242,8 +242,8 @@ func renderDashboard(a *App, s *Session, width, height int) string {
 	if s.Host != nil {
 		swapTotal2, swapUsed2 = s.Host.SwapTotal, s.Host.SwapUsed
 	}
-	cpuPanel := renderCPUPanel(cpuHistory, s.Host, RenderContext{Width: width, Height: cpuPanelH, Theme: theme, WindowLabel: windowLabel, WindowSec: a.windowSeconds(), SpinnerFrame: a.spinnerFrame})
-	memPanel := renderMemPanel(s.Host, s.HostMemUsedHistory.Data(), RenderContext{Width: width, Height: narrowMemH, Theme: theme, WindowLabel: windowLabel, WindowSec: a.windowSeconds(), SpinnerFrame: a.spinnerFrame})
+	cpuPanel := renderCPUPanel(cpuHistory, s.Host, RenderContext{Width: width, Height: cpuPanelH, Theme: theme, WindowLabel: windowLabel, WindowSec: a.windowSeconds(), SpinnerFrame: a.spinnerFrame, Loading: s.BackfillPending})
+	memPanel := renderMemPanel(s.Host, s.HostMemUsedHistory.Data(), RenderContext{Width: width, Height: narrowMemH, Theme: theme, WindowLabel: windowLabel, WindowSec: a.windowSeconds(), SpinnerFrame: a.spinnerFrame, Loading: s.BackfillPending})
 	diskPanel := renderDiskPanel(s.Disks, swapTotal2, swapUsed2, width, diskH, theme)
 	alertPanel := renderAlertPanel(alertPanelOpts{
 		alerts: s.Alerts, width: width, height: alertH, theme: theme,

--- a/internal/tui/panel_host.go
+++ b/internal/tui/panel_host.go
@@ -189,6 +189,9 @@ func formatAutoLabel(v float64) string {
 // renderCPUPanel renders the CPU panel with a multi-row braille graph.
 func renderCPUPanel(cpuHistory []float64, host *protocol.HostMetrics, rc RenderContext) string {
 	title := "Host CPU · " + rc.WindowLabel
+	if rc.Loading {
+		return Box(title, SpinnerViewCentered(rc.SpinnerFrame, "loading...", rc.Theme, rc.Width-2, rc.Height-2), rc.Width, rc.Height, rc.Theme)
+	}
 	if host == nil {
 		return Box(title, SpinnerViewCentered(rc.SpinnerFrame, "waiting for data...", rc.Theme, rc.Width-2, rc.Height-2), rc.Width, rc.Height, rc.Theme)
 	}
@@ -240,6 +243,9 @@ func memDivider(label, value string, width int, labelColor lipgloss.Color, theme
 // renderMemPanel renders the memory panel with a grid-backed braille graph (like CPU).
 func renderMemPanel(host *protocol.HostMetrics, usedHistory []float64, rc RenderContext) string {
 	title := "Host Memory · " + rc.WindowLabel
+	if rc.Loading {
+		return Box(title, SpinnerViewCentered(rc.SpinnerFrame, "loading...", rc.Theme, rc.Width-2, rc.Height-2), rc.Width, rc.Height, rc.Theme)
+	}
 	if host == nil {
 		return Box(title, SpinnerViewCentered(rc.SpinnerFrame, "waiting for data...", rc.Theme, rc.Width-2, rc.Height-2), rc.Width, rc.Height, rc.Theme)
 	}

--- a/internal/tui/render.go
+++ b/internal/tui/render.go
@@ -19,6 +19,7 @@ type RenderContext struct {
 	WindowLabel  string
 	WindowSec    int64
 	SpinnerFrame int
+	Loading      bool // true while a backfill is in-flight (show spinner instead of graph)
 }
 
 // Overlay composites fg centered on top of bg. Both strings are

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -41,6 +41,7 @@ type Session struct {
 	HostCPUHistory     *RingBuffer[float64]
 	HostMemHistory     *RingBuffer[float64]
 	HostMemUsedHistory *RingBuffer[float64]
+	BackfillPending    bool // true while a zoom backfill is in-flight
 
 	// Agent capabilities.
 	RetentionDays int

--- a/internal/tui/tunnel.go
+++ b/internal/tui/tunnel.go
@@ -66,7 +66,7 @@ func (t *Tunnel) start(host, remoteSock string, opts SSHOptions) error {
 	}
 	t.localSock = filepath.Join(dir, "tori.sock")
 
-	args := []string{"-N", "-o", "ControlPath=none"}
+	args := []string{"-N", "-C", "-o", "ControlPath=none"}
 	if opts.Port > 0 {
 		args = append(args, "-p", strconv.Itoa(opts.Port))
 	}
@@ -166,7 +166,7 @@ func NewTunnelAskpass(host, remoteSock string, promptFn AskpassPromptFn, opts SS
 	go t.askpassLoop(promptFn)
 
 	// Build SSH command.
-	args := []string{"-N", "-o", "ControlPath=none"}
+	args := []string{"-N", "-C", "-o", "ControlPath=none"}
 	if opts.Port > 0 {
 		args = append(args, "-p", strconv.Itoa(opts.Port))
 	}


### PR DESCRIPTION
- Server-side log search with CountLogs for "X of Y" display in TUI
- Reduce log buffer from 5000 to 500, add total count to QueryLogsResp
- Enable SSH compression (-C) on all tunnels
- Show loading spinner on graphs during time window changes
- Extract shared helpers to deduplicate log query and filter construction
- Update CLAUDE.md to reflect current file layout and architecture