### PR TITLE
Add alert cooldown and notification rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,16 @@ interval = "10s"
 [alerts.container_down]
 condition = "container.state == 'exited'"
 for = "30s"
+# cooldown = "5m"
+# notify_cooldown = "5m"
 severity = "critical"
 actions = ["notify"]
 
 [alerts.high_cpu]
 condition = "host.cpu_percent > 90"
 for = "2m"
+# cooldown = "5m"
+# notify_cooldown = "5m"
 severity = "warning"
 actions = ["notify"]
 
@@ -214,6 +218,16 @@ Alert conditions use the format `scope.field op value`. Available fields:
 | `container.exit_code` | numeric | Container exit code |
 
 Numeric fields support `>`, `<`, `>=`, `<=`, `==`, `!=`. String fields support `==` and `!=` only, with values in single quotes.
+
+Each alert rule supports these optional timing fields:
+
+| Field | Default | Description |
+|---|---|---|
+| `for` | `0s` | Condition must stay true for this duration before firing |
+| `cooldown` | `5m` | After resolution, wait this long before the same instance can re-fire (prevents flapping) |
+| `notify_cooldown` | `5m` | After notifying for a rule, suppress duplicate notifications for this duration (per-rule, not per-instance) |
+
+Set any of these to `"0s"` to disable.
 
 ## Client Configuration
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -31,12 +31,16 @@ services:
         [alerts.container_down]
         condition = "container.state == 'exited'"
         for = "30s"
+        # cooldown = "5m"
+        # notify_cooldown = "5m"
         severity = "critical"
         actions = ["notify"]
 
         [alerts.high_cpu]
         condition = "host.cpu_percent > 90"
         for = "2m"
+        # cooldown = "5m"
+        # notify_cooldown = "5m"
         severity = "warning"
         actions = ["notify"]
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -259,6 +259,8 @@ if [ ! -f "${CONFIG_DIR}/config.toml" ]; then
 # [alerts.high_cpu]
 # condition = "host.cpu_percent > 90"
 # for = "1m"
+# cooldown = "5m"
+# notify_cooldown = "5m"
 # severity = "critical"
 # actions = ["notify"]
 

--- a/internal/agent/alert_cooldown_test.go
+++ b/internal/agent/alert_cooldown_test.go
@@ -1,0 +1,329 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCooldownPreventsRefire(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"high_cpu": {
+			Condition: "host.cpu_percent > 90",
+			Cooldown:  Duration{5 * time.Minute},
+			Severity:  "critical",
+			Actions:   []string{"notify"},
+		},
+	}
+	a, s := testAlerter(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire.
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	if a.instances["high_cpu"].state != stateFiring {
+		t.Fatal("expected firing")
+	}
+
+	// Resolve.
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 50}})
+
+	// Re-match within cooldown — should stay inactive.
+	now = now.Add(1 * time.Minute)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	inst := a.instances["high_cpu"]
+	if inst != nil && inst.state != stateInactive {
+		t.Fatalf("expected inactive during cooldown, got %d", inst.state)
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("alert rows = %d, want 1 (re-fire suppressed)", count)
+	}
+
+	// Advance past cooldown — should fire normally.
+	now = now.Add(5 * time.Minute)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	inst = a.instances["high_cpu"]
+	if inst == nil || inst.state != stateFiring {
+		t.Fatal("expected firing after cooldown elapsed")
+	}
+
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("alert rows = %d, want 2", count)
+	}
+}
+
+func TestCooldownZeroDisabled(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"high_cpu": {
+			Condition: "host.cpu_percent > 90",
+			Cooldown:  Duration{0}, // explicitly disabled
+			Severity:  "critical",
+			Actions:   []string{"notify"},
+		},
+	}
+	a, s := testAlerter(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire, resolve, re-fire immediately.
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 50}})
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+
+	inst := a.instances["high_cpu"]
+	if inst == nil || inst.state != stateFiring {
+		t.Fatal("expected immediate re-fire with cooldown=0")
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("alert rows = %d, want 2", count)
+	}
+}
+
+func TestCooldownWithForDuration(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"high_cpu": {
+			Condition: "host.cpu_percent > 90",
+			For:       Duration{10 * time.Second},
+			Cooldown:  Duration{5 * time.Minute},
+			Severity:  "warning",
+			Actions:   []string{"notify"},
+		},
+	}
+	a, _ := testAlerter(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire (pending -> firing after for-duration).
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	if a.instances["high_cpu"].state != stateFiring {
+		t.Fatal("expected firing")
+	}
+
+	// Resolve.
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 50}})
+
+	// Re-match within cooldown — should NOT even enter pending.
+	now = now.Add(1 * time.Minute)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	inst := a.instances["high_cpu"]
+	if inst != nil && inst.state != stateInactive {
+		t.Fatalf("expected inactive during cooldown, got %d", inst.state)
+	}
+
+	// Past cooldown — should enter pending.
+	now = now.Add(5 * time.Minute)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	inst = a.instances["high_cpu"]
+	if inst == nil || inst.state != statePending {
+		t.Fatal("expected pending after cooldown elapsed")
+	}
+
+	// After for-duration — should fire.
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	if a.instances["high_cpu"].state != stateFiring {
+		t.Fatal("expected firing after for-duration")
+	}
+}
+
+func TestCooldownPerInstance(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"exited": {
+			Condition: "container.state == 'exited'",
+			Cooldown:  Duration{5 * time.Minute},
+			Severity:  "critical",
+			Actions:   []string{"notify"},
+		},
+	}
+	a, s := testAlerter(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire for "aaa", resolve.
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{{ID: "aaa", Name: "web", State: "exited"}},
+	})
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{{ID: "aaa", Name: "web", State: "running"}},
+	})
+
+	// "bbb" matches same rule within aaa's cooldown — should fire immediately (fresh instance).
+	now = now.Add(1 * time.Minute)
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{
+			{ID: "aaa", Name: "web", State: "running"},
+			{ID: "bbb", Name: "api", State: "exited"},
+		},
+	})
+
+	inst := a.instances["exited:bbb"]
+	if inst == nil || inst.state != stateFiring {
+		t.Fatal("expected exited:bbb firing (cooldown is per-instance)")
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts WHERE instance_key = 'exited:bbb'").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("alert rows for bbb = %d, want 1", count)
+	}
+}
+
+func TestCooldownResetOnGC(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"exited": {
+			Condition: "container.state == 'exited'",
+			Cooldown:  Duration{5 * time.Minute},
+			Severity:  "critical",
+			Actions:   []string{"notify"},
+		},
+	}
+	a, s := testAlerter(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire for "aaa", resolve.
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{{ID: "aaa", Name: "web", State: "exited"}},
+	})
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{{ID: "aaa", Name: "web", State: "running"}},
+	})
+
+	// Container disappears — instance gets GC'd (inactive + unseen).
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{Containers: []ContainerMetrics{}})
+	if _, exists := a.instances["exited:aaa"]; exists {
+		t.Fatal("expected instance GC'd")
+	}
+
+	// Container reappears within what would have been cooldown — fires immediately
+	// because instance was GC'd (fresh instance, zero resolvedAt).
+	now = now.Add(1 * time.Minute)
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{{ID: "aaa", Name: "web", State: "exited"}},
+	})
+
+	inst := a.instances["exited:aaa"]
+	if inst == nil || inst.state != stateFiring {
+		t.Fatal("expected firing (instance was GC'd, cooldown reset)")
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts WHERE instance_key = 'exited:aaa'").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("alert rows = %d, want 2", count)
+	}
+}
+
+func TestCooldownViaContainerEvent(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"exited": {
+			Condition: "container.state == 'exited'",
+			Cooldown:  Duration{5 * time.Minute},
+			Severity:  "critical",
+			Actions:   []string{"notify"},
+		},
+	}
+	a, s := testAlerter(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire via event.
+	a.EvaluateContainerEvent(ctx, ContainerMetrics{ID: "aaa", Name: "web", State: "exited"})
+	a.mu.Lock()
+	if a.instances["exited:aaa"].state != stateFiring {
+		t.Fatal("expected firing")
+	}
+	a.mu.Unlock()
+
+	// Resolve via event.
+	now = now.Add(10 * time.Second)
+	a.EvaluateContainerEvent(ctx, ContainerMetrics{ID: "aaa", Name: "web", State: "running"})
+
+	// Re-match within cooldown via event — should stay inactive.
+	now = now.Add(1 * time.Minute)
+	a.EvaluateContainerEvent(ctx, ContainerMetrics{ID: "aaa", Name: "web", State: "exited"})
+
+	a.mu.Lock()
+	inst := a.instances["exited:aaa"]
+	a.mu.Unlock()
+	if inst != nil && inst.state != stateInactive {
+		t.Fatalf("expected inactive during cooldown, got %d", inst.state)
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts WHERE instance_key = 'exited:aaa'").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("alert rows = %d, want 1 (re-fire suppressed by cooldown)", count)
+	}
+}
+
+func TestCooldownDoesNotAffectFirstFire(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"high_cpu": {
+			Condition: "host.cpu_percent > 90",
+			Cooldown:  Duration{5 * time.Minute},
+			Severity:  "critical",
+			Actions:   []string{"notify"},
+		},
+	}
+	a, s := testAlerter(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// First match — should fire immediately (resolvedAt is zero, cooldown skipped).
+	a.Evaluate(ctx, &MetricSnapshot{Host: &HostMetrics{CPUPercent: 95}})
+	inst := a.instances["high_cpu"]
+	if inst == nil || inst.state != stateFiring {
+		t.Fatal("expected firing on first match")
+	}
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("alert rows = %d, want 1", count)
+	}
+}

--- a/internal/agent/alert_notify_test.go
+++ b/internal/agent/alert_notify_test.go
@@ -1,0 +1,240 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// recordingChannel records notification subjects for test verification.
+type recordingChannel struct {
+	calls []string
+}
+
+func (r *recordingChannel) Send(_ context.Context, subject, _ string) error {
+	r.calls = append(r.calls, subject)
+	return nil
+}
+
+func testAlerterWithRecorder(t *testing.T, alerts map[string]AlertConfig) (*Alerter, *Store, *recordingChannel) {
+	t.Helper()
+	s := testStore(t)
+	rec := &recordingChannel{}
+	n := &Notifier{channels: []Channel{rec}}
+	a, err := NewAlerter(alerts, s, n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a, s, rec
+}
+
+func TestNotifyCooldownSuppresses(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"exited": {
+			Condition:      "container.state == 'exited'",
+			Cooldown:       Duration{0},
+			NotifyCooldown: Duration{5 * time.Minute},
+			Severity:       "critical",
+			Actions:        []string{"notify"},
+		},
+	}
+	a, s, rec := testAlerterWithRecorder(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire "aaa" — notification sent.
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{{ID: "aaa", Name: "web", State: "exited"}},
+	})
+	if len(rec.calls) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(rec.calls))
+	}
+
+	// Fire "bbb" of same rule within window — DB row created, notification suppressed.
+	now = now.Add(10 * time.Second)
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{
+			{ID: "aaa", Name: "web", State: "exited"},
+			{ID: "bbb", Name: "api", State: "exited"},
+		},
+	})
+	if len(rec.calls) != 1 {
+		t.Fatalf("notifications = %d, want 1 (suppressed)", len(rec.calls))
+	}
+
+	// Verify DB row was still created.
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("alert rows = %d, want 2 (both fired in DB)", count)
+	}
+
+	// Advance past window — "ccc" fires and notifies.
+	now = now.Add(5 * time.Minute)
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{
+			{ID: "aaa", Name: "web", State: "exited"},
+			{ID: "bbb", Name: "api", State: "exited"},
+			{ID: "ccc", Name: "db", State: "exited"},
+		},
+	})
+	if len(rec.calls) != 2 {
+		t.Fatalf("notifications = %d, want 2", len(rec.calls))
+	}
+}
+
+func TestNotifyCooldownZeroDisabled(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"exited": {
+			Condition:      "container.state == 'exited'",
+			Cooldown:       Duration{0},
+			NotifyCooldown: Duration{0}, // explicitly disabled
+			Severity:       "critical",
+			Actions:        []string{"notify"},
+		},
+	}
+	a, _, rec := testAlerterWithRecorder(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire two containers — both should notify independently.
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{
+			{ID: "aaa", Name: "web", State: "exited"},
+			{ID: "bbb", Name: "api", State: "exited"},
+		},
+	})
+	if len(rec.calls) != 2 {
+		t.Fatalf("notifications = %d, want 2 (cooldown disabled)", len(rec.calls))
+	}
+}
+
+func TestNotifyCooldownPerRule(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"exited": {
+			Condition:      "container.state == 'exited'",
+			Cooldown:       Duration{0},
+			NotifyCooldown: Duration{5 * time.Minute},
+			Severity:       "critical",
+			Actions:        []string{"notify"},
+		},
+		"unhealthy": {
+			Condition:      "container.health == 'unhealthy'",
+			Cooldown:       Duration{0},
+			NotifyCooldown: Duration{5 * time.Minute},
+			Severity:       "warning",
+			Actions:        []string{"notify"},
+		},
+	}
+	a, _, rec := testAlerterWithRecorder(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Fire one instance of each rule — 2 notifications (independent timers).
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{
+			{ID: "aaa", Name: "web", State: "exited", Health: "unhealthy"},
+		},
+	})
+	if len(rec.calls) != 2 {
+		t.Fatalf("notifications = %d, want 2 (one per rule)", len(rec.calls))
+	}
+}
+
+func TestNotifyCooldownDoesNotAffectAlertCreation(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"exited": {
+			Condition:      "container.state == 'exited'",
+			Cooldown:       Duration{0},
+			NotifyCooldown: Duration{5 * time.Minute},
+			Severity:       "critical",
+			Actions:        []string{"notify"},
+		},
+	}
+	a, s, _ := testAlerterWithRecorder(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	var callbacks []string
+	a.onStateChange = func(alert *Alert, state string) {
+		callbacks = append(callbacks, state+":"+alert.InstanceKey)
+	}
+
+	// Fire two containers — both create DB rows and trigger onStateChange,
+	// even though second notification is suppressed.
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{
+			{ID: "aaa", Name: "web", State: "exited"},
+			{ID: "bbb", Name: "api", State: "exited"},
+		},
+	})
+
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("alert rows = %d, want 2", count)
+	}
+	if len(callbacks) != 2 {
+		t.Errorf("callbacks = %d, want 2", len(callbacks))
+	}
+}
+
+func TestNotifyCooldownSilenceInteraction(t *testing.T) {
+	alerts := map[string]AlertConfig{
+		"exited": {
+			Condition:      "container.state == 'exited'",
+			Cooldown:       Duration{0},
+			NotifyCooldown: Duration{5 * time.Minute},
+			Severity:       "critical",
+			Actions:        []string{"notify"},
+		},
+	}
+	a, _, rec := testAlerterWithRecorder(t, alerts)
+	ctx := context.Background()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return now }
+
+	// Silence rule, fire "aaa" — silenced, no notification, lastNotified NOT set.
+	a.Silence("exited", 1*time.Minute)
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{{ID: "aaa", Name: "web", State: "exited"}},
+	})
+	if len(rec.calls) != 0 {
+		t.Fatalf("notifications = %d, want 0 (silenced)", len(rec.calls))
+	}
+
+	// Verify lastNotified was NOT set by silenced fire.
+	a.mu.Lock()
+	_, hasLast := a.lastNotified["exited"]
+	a.mu.Unlock()
+	if hasLast {
+		t.Fatal("lastNotified should not be set when silenced")
+	}
+
+	// Unsilence (advance past silence duration).
+	now = now.Add(2 * time.Minute)
+
+	// Fire "bbb" — should notify (silence expired, no prior lastNotified to cooldown against).
+	a.Evaluate(ctx, &MetricSnapshot{
+		Containers: []ContainerMetrics{
+			{ID: "aaa", Name: "web", State: "exited"},
+			{ID: "bbb", Name: "api", State: "exited"},
+		},
+	})
+	if len(rec.calls) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(rec.calls))
+	}
+}

--- a/internal/agent/alert_test.go
+++ b/internal/agent/alert_test.go
@@ -1275,3 +1275,4 @@ func TestContainerExitCodeAlert(t *testing.T) {
 		t.Errorf("expected resolved, got state %d", inst.state)
 	}
 }
+

--- a/internal/agent/socket.go
+++ b/internal/agent/socket.go
@@ -701,6 +701,12 @@ func (c *connState) queryAlertRules(id uint32) {
 			if rs.For > 0 {
 				info.For = rs.For.String()
 			}
+			if rs.Cooldown > 0 {
+				info.Cooldown = rs.Cooldown.String()
+			}
+			if rs.NotifyCooldown > 0 {
+				info.NotifyCooldown = rs.NotifyCooldown.String()
+			}
 			if !rs.SilencedUntil.IsZero() {
 				info.SilencedUntil = rs.SilencedUntil.Unix()
 			}

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -211,13 +211,15 @@ type SilenceAlertReq struct {
 
 // AlertRuleInfo describes a configured alert rule and its current status.
 type AlertRuleInfo struct {
-	Name         string   `msgpack:"name"`
-	Condition    string   `msgpack:"condition"`
-	Severity     string   `msgpack:"severity"`
-	For          string   `msgpack:"for,omitempty"`
-	Actions      []string `msgpack:"actions"`
-	FiringCount  int      `msgpack:"firing_count"`
-	SilencedUntil int64   `msgpack:"silenced_until,omitempty"` // unix timestamp, 0 = not silenced
+	Name           string   `msgpack:"name"`
+	Condition      string   `msgpack:"condition"`
+	Severity       string   `msgpack:"severity"`
+	For            string   `msgpack:"for,omitempty"`
+	Cooldown       string   `msgpack:"cooldown,omitempty"`
+	NotifyCooldown string   `msgpack:"notify_cooldown,omitempty"`
+	Actions        []string `msgpack:"actions"`
+	FiringCount    int      `msgpack:"firing_count"`
+	SilencedUntil  int64    `msgpack:"silenced_until,omitempty"` // unix timestamp, 0 = not silenced
 }
 
 // QueryAlertRulesResp is the response for TypeQueryAlertRules.


### PR DESCRIPTION
- Per-instance cooldown suppresses re-fire after resolution (default 5m)
- Per-rule notify_cooldown rate-limits notifications (default 5m)
- Both configurable per alert rule, 0 to disable, TOML metadata distinguishes absent vs zero
- Propagate cooldown fields to protocol.AlertRuleInfo and socket handler
- Reject negative durations for for/cooldown/notify_cooldown in config validation