### PR TITLE
Fix SocketServer retentionDays not updated on config reload

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -179,6 +179,7 @@ func (a *Agent) applyConfig(newCfg *Config) {
 
 	// Docker filters.
 	a.docker.SetFilters(newCfg.Docker.Include, newCfg.Docker.Exclude)
+	a.socket.SetRetentionDays(newCfg.Storage.RetentionDays)
 
 	// Rebuild alerter + notifier if alert/notify config changed.
 	if len(newCfg.Alerts) > 0 {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -149,6 +149,9 @@ func TestApplyConfigUpdatesFields(t *testing.T) {
 	if a.cfg.Storage.RetentionDays != 14 {
 		t.Errorf("retention = %d, want 14", a.cfg.Storage.RetentionDays)
 	}
+	if got := ss.retentionDays.Load(); got != 14 {
+		t.Errorf("socket retentionDays = %d, want 14", got)
+	}
 	if a.cfg.Collect.Interval.Duration != 30*time.Second {
 		t.Errorf("interval = %s, want 30s", a.cfg.Collect.Interval.Duration)
 	}


### PR DESCRIPTION
retentionDays was set once at construction but never propagated during SIGHUP reload. Changed to atomic.Int32 for thread-safe access and added SetRetentionDays() called from applyConfig().