### PR TITLE
Fix context.Context propagation across agent, socket server, and TUI

### DIFF
--- a/cmd/tori/main.go
+++ b/cmd/tori/main.go
@@ -89,9 +89,14 @@ func runAgent(args []string) {
 	sighup := make(chan os.Signal, 1)
 	signal.Notify(sighup, syscall.SIGHUP)
 	go func() {
-		for range sighup {
-			if err := a.Reload(); err != nil {
-				slog.Error("config reload failed", "error", err)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-sighup:
+				if err := a.Reload(); err != nil {
+					slog.Error("config reload failed", "error", err)
+				}
 			}
 		}
 	}()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -143,7 +143,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		case <-ticker.C:
 			a.collect(ctx)
 		case newCfg := <-a.reload:
-			a.applyConfig(newCfg)
+			a.applyConfig(ctx, newCfg)
 			ticker.Reset(a.cfg.Collect.Interval.Duration)
 		}
 	}
@@ -168,7 +168,7 @@ func nonReloadableFields(old, updated *Config) {
 	}
 }
 
-func (a *Agent) applyConfig(newCfg *Config) {
+func (a *Agent) applyConfig(ctx context.Context, newCfg *Config) {
 	nonReloadableFields(a.cfg, newCfg)
 
 	// Reloadable fields.
@@ -191,14 +191,14 @@ func (a *Agent) applyConfig(newCfg *Config) {
 		}
 		alerter.onStateChange = a.makeOnStateChange()
 		if a.alerter != nil {
-			a.alerter.ResolveAll()
+			a.alerter.ResolveAll(ctx)
 		}
 		a.alerter = alerter
 		a.socket.SetAlerter(alerter)
 		a.events.SetAlerter(alerter)
 	} else {
 		if a.alerter != nil {
-			a.alerter.ResolveAll()
+			a.alerter.ResolveAll(ctx)
 		}
 		a.alerter = nil
 		a.socket.SetAlerter(nil)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -144,7 +144,7 @@ func TestApplyConfigUpdatesFields(t *testing.T) {
 		Docker:  DockerConfig{Include: []string{"api-*"}, Exclude: []string{"test-*"}},
 	}
 
-	a.applyConfig(newCfg)
+	a.applyConfig(context.Background(),newCfg)
 
 	if a.cfg.Storage.RetentionDays != 14 {
 		t.Errorf("retention = %d, want 14", a.cfg.Storage.RetentionDays)
@@ -216,7 +216,7 @@ func TestApplyConfigRebuildsAlerter(t *testing.T) {
 		},
 	}
 
-	a.applyConfig(newCfg)
+	a.applyConfig(context.Background(),newCfg)
 
 	if a.alerter == nil {
 		t.Fatal("alerter should be set after reload with alert rules")
@@ -231,7 +231,7 @@ func TestApplyConfigRebuildsAlerter(t *testing.T) {
 		Collect: CollectConfig{Interval: Duration{Duration: 10 * time.Second}},
 	}
 
-	a.applyConfig(noAlertCfg)
+	a.applyConfig(context.Background(),noAlertCfg)
 
 	if a.alerter != nil {
 		t.Error("alerter should be nil after reload without alert rules")

--- a/internal/agent/alert.go
+++ b/internal/agent/alert.go
@@ -412,13 +412,13 @@ func (a *Alerter) AdoptFiring(ctx context.Context) error {
 }
 
 // ResolveAll resolves all firing alerts. Called before replacing the alerter on config reload.
-func (a *Alerter) ResolveAll() {
+func (a *Alerter) ResolveAll(ctx context.Context) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	now := a.now()
 	for key, inst := range a.instances {
 		if inst.state == stateFiring {
-			a.resolve(context.Background(), a.ruleForKey(key), key, inst, now)
+			a.resolve(ctx, a.ruleForKey(key), key, inst, now)
 		}
 	}
 }

--- a/internal/agent/alert_integration_test.go
+++ b/internal/agent/alert_integration_test.go
@@ -889,7 +889,7 @@ func TestShutdownResolvesAlerts(t *testing.T) {
 	}
 
 	// Simulate shutdown.
-	alerter.ResolveAll()
+	alerter.ResolveAll(context.Background())
 
 	firing, _ = s.QueryFiringAlerts(ctx)
 	if len(firing) != 0 {

--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -105,7 +105,7 @@ func (ew *EventWatcher) watch(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			ew.handleEvent(msg)
+			ew.handleEvent(ctx, msg)
 		}
 	}
 }
@@ -138,7 +138,7 @@ const (
 	maxActionLen      = 64
 )
 
-func (ew *EventWatcher) handleEvent(msg events.Message) {
+func (ew *EventWatcher) handleEvent(ctx context.Context, msg events.Message) {
 	action := msg.Action
 	actionStr := string(action)
 
@@ -211,7 +211,7 @@ func (ew *EventWatcher) handleEvent(msg events.Message) {
 			if isHealth {
 				cm.State = "running"
 			}
-			alerter.EvaluateContainerEvent(context.Background(), cm)
+			alerter.EvaluateContainerEvent(ctx, cm)
 		}
 	}
 }


### PR DESCRIPTION
- Pass context through EventWatcher.handleEvent to EvaluateContainerEvent
- Add context parameter to Alerter.ResolveAll and Agent.applyConfig
- Make SIGHUP handler exit on context cancellation (goroutine leak fix)
- Use context-aware net.Dialer in emailChannel.Send
- Add server-level context to SocketServer for connection lifecycle
- Wire up Session.connectCancel in TUI for cancellable connections