### PR TITLE
Show loading sparklines when switching historic time windows

### DIFF
--- a/internal/tui/app_key.go
+++ b/internal/tui/app_key.go
@@ -192,6 +192,8 @@ func (a *App) handleZoom(key string) tea.Cmd {
 
 	// Re-backfill detail metrics when in detail view.
 	if a.view == viewDetail {
+		s.Detail.cpuHist = NewRingBuffer[float64](histBufSize)
+		s.Detail.memHist = NewRingBuffer[float64](histBufSize)
 		s.Detail.metricsBackfilled = false
 		s.Detail.metricsBackfillPending = false
 		if cmd := s.Detail.onSwitch(s.Client, a.windowSeconds(), s.RetentionDays); cmd != nil {

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -245,13 +245,19 @@ func renderHostGraphs(a *App, s *Session, w int, theme *Theme) string {
 	indent := strings.Repeat(" ", labelW)
 	pctPad := strings.Repeat(" ", pctW)
 
-	if s.Host == nil {
+	if s.Host == nil || s.BackfillPending {
 		cpuTop, cpuBot := LoadingSparkline(a.spinnerFrame, graphW, theme.FgDim)
 		memTop, memBot := LoadingSparkline(a.spinnerFrame+3, graphW, theme.FgDim)
+		cpuPct := pctPad
+		memPct := pctPad
+		if s.Host != nil {
+			cpuPct = muted.Render(rightAlign(fmt.Sprintf(" %.1f%%", s.Host.CPUPercent), pctW))
+			memPct = muted.Render(rightAlign(fmt.Sprintf(" %.1f%%", s.Host.MemPercent), pctW))
+		}
 		return indent + cpuTop + pctPad + "\n" +
-			muted.Render("cpu ") + cpuBot + pctPad + "\n" +
+			muted.Render("cpu ") + cpuBot + cpuPct + "\n" +
 			indent + memTop + pctPad + "\n" +
-			muted.Render("mem ") + memBot + pctPad
+			muted.Render("mem ") + memBot + memPct
 	}
 
 	cpuTop, cpuBot := Sparkline(s.HostCPUHist.Data(), graphW, theme.GraphCPU)


### PR DESCRIPTION
Previously graphs went blank while backfill was in-flight. Now the animated loading sparkline plays during the fetch, with current live values still visible on the right.