### PR TITLE
Fix alert list flickering caused by unstable sort order

### DIFF
--- a/internal/tui/alerts.go
+++ b/internal/tui/alerts.go
@@ -118,7 +118,10 @@ func buildAlertList(firing map[int64]*protocol.AlertEvent, resolved []protocol.A
 		})
 	}
 	sort.Slice(items, func(i, j int) bool {
-		return items[i].firedAt > items[j].firedAt
+		if items[i].firedAt != items[j].firedAt {
+			return items[i].firedAt > items[j].firedAt
+		}
+		return items[i].id < items[j].id
 	})
 
 	if !showResolved {
@@ -145,7 +148,10 @@ func buildAlertList(firing map[int64]*protocol.AlertEvent, resolved []protocol.A
 		})
 	}
 	sort.Slice(resolvedItems, func(i, j int) bool {
-		return resolvedItems[i].resolvedAt > resolvedItems[j].resolvedAt
+		if resolvedItems[i].resolvedAt != resolvedItems[j].resolvedAt {
+			return resolvedItems[i].resolvedAt > resolvedItems[j].resolvedAt
+		}
+		return resolvedItems[i].id < resolvedItems[j].id
 	})
 
 	items = append(items, resolvedItems...)

--- a/internal/tui/detail_log.go
+++ b/internal/tui/detail_log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -472,6 +473,7 @@ func containerAlerts(alerts map[int64]*protocol.AlertEvent, containerID string) 
 			out = append(out, a)
 		}
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out
 }
 


### PR DESCRIPTION
Map iteration is non-deterministic in Go. Add alert ID as a tiebreaker to all sort comparisons so alerts with the same timestamp render in a stable order.