### PR TITLE
Add Severity and Status fields to webhook templates

### DIFF
--- a/internal/agent/alert.go
+++ b/internal/agent/alert.go
@@ -328,8 +328,9 @@ func (a *Alerter) fire(ctx context.Context, ec *evalContext, inst *alertInstance
 			}
 			a.lastNotified[r.name] = now
 			ruleName := r.name
+			severity := r.severity
 			a.deferred = append(a.deferred, func() {
-				a.notifier.Send("Alert: "+ruleName, msg)
+				a.notifier.SendAlert("Alert: "+ruleName, msg, severity, "firing")
 			})
 		}
 	}


### PR DESCRIPTION
Thread severity/status through the notification pipeline so webhook templates can use {{.Severity}} and {{.Status}} for conditional formatting in Slack/Discord/Teams integrations.