### PR TITLE
Add log-based alert rules (log.count condition scope)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,11 +132,13 @@ Code is a liability, not an asset. Every line we write is a line we have to main
 
 ### Alert system
 
-- Conditions are 3-token strings: `scope.field op value` (e.g., `host.cpu_percent > 90`, `container.state == 'exited'`).
-- Host fields: `cpu_percent`, `memory_percent`, `disk_percent`, `load1`, `load5`, `load15`, `swap_percent`. Container fields: `cpu_percent`, `cpu_limit_percent`, `memory_percent`, `state`, `health`, `restart_count`, `exit_code`.
+- Conditions are 3-token strings: `scope.field op value` (e.g., `host.cpu_percent > 90`, `container.state == 'exited'`, `log.count > 5`).
+- Three scopes: `host`, `container`, `log`.
+- Host fields: `cpu_percent`, `memory_percent`, `disk_percent`, `load1`, `load5`, `load15`, `swap_percent`. Container fields: `cpu_percent`, `cpu_limit_percent`, `memory_percent`, `state`, `health`, `restart_count`, `exit_code`. Log fields: `count`.
 - `cpu_limit_percent` = `CPUPercent / CPULimit` when a CPU limit is configured, 0 when not. Preferred over `cpu_percent` for container alerts since it's relative to the container's actual constraint.
+- **Log rules** require `match` (pattern), `window` (duration), and optionally `match_regex` (bool) in AlertConfig. Evaluated per-container via `CountLogMatches()` SQL query grouped by container_id. One query per log rule per collect cycle.
 - Field names are validated against a whitelist in `parseCondition`. String fields (`state`, `health`) only allow `==`/`!=`.
-- Alerter instances are keyed: `rulename` for host, `rulename:containerID` for container, `rulename:mountpoint` for disk.
+- Alerter instances are keyed: `rulename` for host, `rulename:containerID` for container and log, `rulename:mountpoint` for disk.
 - State machine: inactive → pending (if `for > 0`) → firing → resolved → inactive. `for = 0` skips pending.
 - Inactive unseen instances are GC'd from the map to prevent unbounded growth with ephemeral containers.
 - When collection fails (nil snapshot field), existing instances are marked as `seen` to avoid false resolution.

--- a/demo/config.toml
+++ b/demo/config.toml
@@ -19,3 +19,10 @@ condition = "container.memory_percent > 80"
 for = "30s"
 severity = "warning"
 actions = ["notify"]
+
+[alerts.error_spike]
+condition = "log.count > 10"
+match = "error"
+window = "5m"
+severity = "warning"
+actions = ["notify"]

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -91,5 +91,20 @@ services:
         severity = "warning"
         actions = ["notify"]
 
+        # [alerts.error_spike]
+        # condition = "log.count > 10"
+        # match = "error"                    # substring match (case-insensitive)
+        # window = "5m"
+        # severity = "warning"
+        # actions = ["notify"]
+
+        # [alerts.oom_kills]
+        # condition = "log.count > 0"
+        # match = "OOM|out of memory"        # regex match
+        # match_regex = true
+        # window = "10m"
+        # severity = "critical"
+        # actions = ["notify"]
+
 volumes:
   tori-data:

--- a/internal/agent/condition.go
+++ b/internal/agent/condition.go
@@ -26,6 +26,9 @@ var validFields = map[string]map[string]bool{
 		"restart_count":     true,
 		"exit_code":         true,
 	},
+	"log": {
+		"count": true,
+	},
 }
 
 // String-only fields that only support == and != operators.
@@ -36,8 +39,8 @@ var stringFields = map[string]bool{
 
 // Condition represents a parsed alert condition like "host.cpu_percent > 90".
 type Condition struct {
-	Scope  string  // "host" or "container"
-	Field  string  // "cpu_percent", "memory_percent", "disk_percent", "state"
+	Scope  string  // "host", "container", or "log"
+	Field  string  // "cpu_percent", "memory_percent", "disk_percent", "state", "count"
 	Op     string  // ">", "<", ">=", "<=", "==", "!="
 	NumVal float64 // numeric threshold (when IsStr is false)
 	StrVal string  // string value (when IsStr is true)
@@ -62,9 +65,9 @@ func parseCondition(s string) (Condition, error) {
 	}
 
 	switch c.Scope {
-	case "host", "container":
+	case "host", "container", "log":
 	default:
-		return Condition{}, fmt.Errorf("unknown scope %q (must be host or container)", c.Scope)
+		return Condition{}, fmt.Errorf("unknown scope %q (must be host, container, or log)", c.Scope)
 	}
 
 	fields, ok := validFields[c.Scope]

--- a/internal/agent/condition_test.go
+++ b/internal/agent/condition_test.go
@@ -26,6 +26,9 @@ func TestParseCondition(t *testing.T) {
 		{"container.health == 'unhealthy'", "container", "health", "==", 0, "unhealthy", true, false},
 		{"container.restart_count > 5", "container", "restart_count", ">", 5, "", false, false},
 		{"container.exit_code != 0", "container", "exit_code", "!=", 0, "", false, false},
+		{"log.count > 5", "log", "count", ">", 5, "", false, false},
+		{"log.count >= 1", "log", "count", ">=", 1, "", false, false},
+		{"log.count == 0", "log", "count", "==", 0, "", false, false},
 
 		// Invalid cases.
 		{"", "", "", "", 0, "", false, true},
@@ -37,6 +40,7 @@ func TestParseCondition(t *testing.T) {
 		{"unknown.cpu_percent > 90", "", "", "", 0, "", false, true},    // bad scope
 		{"host.unknown_field > 2", "", "", "", 0, "", false, true},      // unknown field
 		{"container.image == 'nginx'", "", "", "", 0, "", false, true},  // unknown field
+		{"log.message == 'error'", "", "", "", 0, "", false, true},      // unknown log field
 		{"container.state > 'exited'", "", "", "", 0, "", false, true},  // string field with > op
 		{"container.state >= 'a'", "", "", "", 0, "", false, true},      // string field with >= op
 	}

--- a/internal/agent/socket.go
+++ b/internal/agent/socket.go
@@ -835,6 +835,13 @@ func (c *connState) queryAlertRules(id uint32) {
 			if !rs.SilencedUntil.IsZero() {
 				info.SilencedUntil = rs.SilencedUntil.Unix()
 			}
+			if rs.Match != "" {
+				info.Match = rs.Match
+				info.MatchRegex = rs.MatchRegex
+			}
+			if rs.Window > 0 {
+				info.Window = rs.Window.String()
+			}
 			rules = append(rules, info)
 		}
 	}

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -246,6 +246,9 @@ type AlertRuleInfo struct {
 	Actions        []string `msgpack:"actions"`
 	FiringCount    int      `msgpack:"firing_count"`
 	SilencedUntil  int64    `msgpack:"silenced_until,omitempty"` // unix timestamp, 0 = not silenced
+	Match          string   `msgpack:"match,omitempty"`
+	MatchRegex     bool     `msgpack:"match_regex,omitempty"`
+	Window         string   `msgpack:"window,omitempty"`
 }
 
 // QueryAlertRulesResp is the response for TypeQueryAlertRules.


### PR DESCRIPTION
New alert rule type that fires when a log pattern matches X times within a time window. Uses the existing condition grammar (log.count > 5) with match, match_regex, and window config fields. Evaluation runs one grouped SQL COUNT query per rule per collect cycle against the logs table.