### PR TITLE
Add SMTP authentication and TLS support for email notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,9 @@ Code is a liability, not an asset. Every line we write is a line we have to main
 - Webhook config: `URL`, `Headers` (custom, sanitized against CRLF injection), `Template` (Go template for custom payload body).
 - Default webhook payload if no template: `{"text": "*Subject*\nBody"}`.
 - `Notifier.Send()` errors are logged, not fatal — collect loop continues.
+- `EmailConfig` supports optional SMTP auth (`username`/`password`) and TLS (`tls`: `"starttls"`, `"tls"`, or `"none"`).
+- Auth requires TLS — validation rejects credentials when `tls` is `"none"` or unset.
+- Uses `smtp.PlainAuth` (stdlib). Go's implementation refuses to send credentials without TLS.
 
 ### Networking gotchas
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,9 @@ smtp_host = "smtp.example.com"
 smtp_port = 587
 from = "tori@example.com"
 to = ["you@example.com"]
+username = "tori@example.com"
+password = "app-password-here"
+tls = "starttls"
 
 [[notify.webhooks]]
 enabled = true
@@ -317,6 +320,8 @@ url = "https://hooks.slack.com/services/..."
 ```
 
 Webhook template fields: `{{.Subject}}`, `{{.Body}}`, `{{.Severity}}` (warning/critical), `{{.Status}}` (firing/resolved/test).
+
+**Email TLS modes:** `starttls` (port 587, upgrades to TLS after connect), `tls` (port 465, implicit TLS), or omit for local relay (no encryption). Authentication (`username`/`password`) requires TLS.
 
 ### Alert reference
 

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -440,6 +440,127 @@ to = ["admin@example.com"]
 `,
 			wantErr: true,
 		},
+		{
+			name: "valid starttls with auth",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 587
+from = "alerts@example.com"
+to = ["admin@example.com"]
+username = "user@example.com"
+password = "secret"
+tls = "starttls"
+`,
+		},
+		{
+			name: "valid implicit tls with auth",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 465
+from = "alerts@example.com"
+to = ["admin@example.com"]
+username = "user@example.com"
+password = "secret"
+tls = "tls"
+`,
+		},
+		{
+			name: "valid no auth no tls",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "localhost"
+smtp_port = 25
+from = "alerts@example.com"
+to = ["admin@example.com"]
+`,
+		},
+		{
+			name: "valid starttls without auth",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 587
+from = "alerts@example.com"
+to = ["admin@example.com"]
+tls = "starttls"
+`,
+		},
+		{
+			name: "invalid tls value",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 587
+from = "alerts@example.com"
+to = ["admin@example.com"]
+tls = "auto"
+`,
+			wantErr: true,
+		},
+		{
+			name: "username without password",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 587
+from = "alerts@example.com"
+to = ["admin@example.com"]
+username = "user@example.com"
+tls = "starttls"
+`,
+			wantErr: true,
+		},
+		{
+			name: "password without username",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 587
+from = "alerts@example.com"
+to = ["admin@example.com"]
+password = "secret"
+tls = "starttls"
+`,
+			wantErr: true,
+		},
+		{
+			name: "auth without tls",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 587
+from = "alerts@example.com"
+to = ["admin@example.com"]
+username = "user@example.com"
+password = "secret"
+`,
+			wantErr: true,
+		},
+		{
+			name: "auth with tls none",
+			config: `
+[notify.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 587
+from = "alerts@example.com"
+to = ["admin@example.com"]
+username = "user@example.com"
+password = "secret"
+tls = "none"
+`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The email channel only worked with open relays or localhost. Add username/password auth (PLAIN) and TLS modes (starttls for port 587, implicit tls for port 465) so it works with real SMTP providers.

Validation rejects credentials without TLS to prevent plaintext credential transmission. Go's smtp.PlainAuth provides a second layer of defense-in-depth.