### PR TITLE
Remove :main Docker image build from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  packages: write
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,36 +21,3 @@ jobs:
 
       - name: Test
         run: go test -race ./...
-
-  # Build and push :main Docker image on every push to main.
-  # Used for dev testing via Dokploy/Coolify.
-  docker-main:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Build binary
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w -X main.version=main-${GITHUB_SHA::8}" -o tori ./cmd/tori
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: deploy/Dockerfile.release
-          push: true
-          tags: ghcr.io/thobiasn/tori-cli:main


### PR DESCRIPTION
No longer needed now that prereleases are supported via goreleaser. Use prerelease tags (e.g. v0.3.0-rc.1) for testing instead.