### PR TITLE
Fix webhook JSON escaping and regex case-insensitive scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ window = "5m"
 severity = "warning"
 actions = ["notify"]
 
-[alerts.oom_kills]
+[alerts.mem_killed]
 condition = "log.count > 0"
 match = "OOM|out of memory"
 match_regex = true
@@ -316,7 +316,7 @@ url = "https://hooks.slack.com/services/..."
 # template = '{"text": "{{.Subject}}\n{{.Body}}\nSeverity: {{.Severity}} Status: {{.Status}}"}'
 ```
 
-Webhook template fields: `{{.Subject}}`, `{{.Body}}`, `{{.Severity}}` (warning/critical), `{{.Status}}` (firing/resolved/test).
+Webhook template fields: `{{.Subject}}`, `{{.Body}}`, `{{.Severity}}` (warning/critical), `{{.Status}}` (firing/resolved/test). All values are automatically JSON-escaped when using a custom template.
 
 ### Alert reference
 

--- a/internal/agent/notify.go
+++ b/internal/agent/notify.go
@@ -235,6 +235,15 @@ type webhookData struct {
 	Status   string
 }
 
+// jsonEscape escapes a string for safe embedding inside a JSON string value.
+// It uses json.Marshal to handle all special characters, then strips the
+// surrounding quotes that Marshal adds.
+func jsonEscape(s string) string {
+	b, _ := json.Marshal(s)
+	// Strip surrounding quotes: "foo" → foo
+	return string(b[1 : len(b)-1])
+}
+
 func newWebhookChannel(cfg WebhookConfig) *webhookChannel {
 	wc := &webhookChannel{cfg: cfg}
 	if cfg.Template != "" {
@@ -249,10 +258,10 @@ func (w *webhookChannel) Send(ctx context.Context, n notification) error {
 	if w.tmpl != nil {
 		var buf bytes.Buffer
 		data := webhookData{
-			Subject:  n.subject,
-			Body:     n.body,
-			Severity: n.severity,
-			Status:   n.status,
+			Subject:  jsonEscape(n.subject),
+			Body:     jsonEscape(n.body),
+			Severity: jsonEscape(n.severity),
+			Status:   jsonEscape(n.status),
 		}
 		if err := w.tmpl.Execute(&buf, data); err != nil {
 			return fmt.Errorf("template execute: %w", err)

--- a/internal/agent/store_queries.go
+++ b/internal/agent/store_queries.go
@@ -427,7 +427,7 @@ func (s *Store) CountLogMatches(ctx context.Context, pattern string, isRegex boo
 
 	if isRegex {
 		query = `SELECT container_id, COUNT(*) FROM logs WHERE timestamp >= ? AND timestamp <= ? AND message REGEXP ? GROUP BY container_id`
-		args = []any{start, end, "(?i)" + pattern}
+		args = []any{start, end, "(?i)(?:" + pattern + ")"}
 	} else {
 		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(pattern)
 		query = `SELECT container_id, COUNT(*) FROM logs WHERE timestamp >= ? AND timestamp <= ? AND message LIKE ? ESCAPE '\' GROUP BY container_id`
@@ -477,7 +477,7 @@ func (s *Store) QueryLogs(ctx context.Context, f LogFilter) ([]LogEntry, error) 
 	if f.Search != "" {
 		if f.SearchIsRegex {
 			query += ` AND message REGEXP ?`
-			args = append(args, "(?i)"+f.Search)
+			args = append(args, "(?i)(?:"+f.Search+")")
 		} else {
 			query += ` AND message LIKE ? ESCAPE '\'`
 			escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(f.Search)


### PR DESCRIPTION
Custom webhook templates broke with 400 errors when alert messages contained double quotes (all log-scoped alerts use %q formatting). Template values are now automatically JSON-escaped before interpolation.

Fix regex (?i) flag only applying to the first alternative in patterns with |, in both CountLogMatches and QueryLogs. Wrap the user pattern in a non-capturing group so the flag covers the entire expression.

Rename example alert from oom_kills to mem_killed to avoid the rule name matching its own log pattern when tori's container is tracked.