### PR TITLE
Skip update check for prerelease versions

### DIFF
--- a/cmd/tori/main.go
+++ b/cmd/tori/main.go
@@ -72,7 +72,7 @@ func runAskpass(sock string) {
 func runVersion() {
 	fmt.Println("tori " + version)
 
-	if version == "dev" {
+	if version == "dev" || strings.Contains(version, "-") {
 		return
 	}
 


### PR DESCRIPTION
Prerelease versions (containing "-", e.g. 0.3.0-rc.1) would incorrectly show "update available" pointing to the older stable release since releases/latest ignores prereleases.