### PR TITLE
Specify home dir and shell in sysusers, add /var/lib/tori to tmpfiles

### DIFF
--- a/deploy/tori.sysusers
+++ b/deploy/tori.sysusers
@@ -1,1 +1,1 @@
-u tori - "Tori monitoring agent"
+u tori - "Tori monitoring agent" /var/lib/tori /usr/sbin/nologin

--- a/deploy/tori.tmpfiles
+++ b/deploy/tori.tmpfiles
@@ -1,1 +1,2 @@
+d /var/lib/tori 0750 tori tori -
 d /run/tori 0750 tori tori -


### PR DESCRIPTION
Brings the systemd declarative config in line with what install.sh already does: set the tori user's home to /var/lib/tori with nologin shell, and ensure the data directory is created on boot.