### PR TITLE
Fix OOM log alert regex to use word boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ actions = ["notify"]
 
 [alerts.mem_killed]
 condition = "log.count > 0"
-match = "OOM|out of memory"
+match = "\\bOOM\\b|\\bout of memory\\b"
 match_regex = true
 window = "10m"
 severity = "critical"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -101,7 +101,7 @@ services:
 
         # [alerts.oom_kills]
         # condition = "log.count > 0"
-        # match = "OOM|out of memory"        # regex match
+        # match = "\\bOOM\\b|\\bout of memory\\b"        # regex match
         # match_regex = true
         # window = "10m"
         # severity = "critical"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -272,11 +272,81 @@ if [ ! -f "${CONFIG_DIR}/config.toml" ]; then
 [collect]
 # interval = "10s"
 
-# [alerts.high_cpu]
-# condition = "host.cpu_percent > 90"
-# for = "1m"
+[alerts.container_down]
+condition = "container.state == 'exited'"
+for = "30s"
 # cooldown = "5m"
 # notify_cooldown = "5m"
+severity = "critical"
+actions = ["notify"]
+
+[alerts.high_cpu]
+condition = "host.cpu_percent > 90"
+for = "2m"
+# cooldown = "5m"
+# notify_cooldown = "5m"
+severity = "warning"
+actions = ["notify"]
+
+[alerts.high_memory]
+condition = "host.memory_percent > 85"
+for = "1m"
+severity = "warning"
+actions = ["notify"]
+
+[alerts.disk_space]
+condition = "host.disk_percent > 90"
+for = "0s"
+severity = "critical"
+actions = ["notify"]
+
+# [alerts.high_load]
+# condition = "host.load1 > 4"     # tune threshold to your CPU count
+# for = "5m"
+# severity = "warning"
+# actions = ["notify"]
+
+[alerts.high_swap]
+condition = "host.swap_percent > 80"
+for = "2m"
+severity = "warning"
+actions = ["notify"]
+
+[alerts.container_memory]
+condition = "container.memory_percent > 90"
+for = "1m"
+severity = "warning"
+actions = ["notify"]
+
+[alerts.unhealthy]
+condition = "container.health == 'unhealthy'"
+for = "30s"
+severity = "critical"
+actions = ["notify"]
+
+[alerts.restart_loop]
+condition = "container.restart_count > 5"
+severity = "critical"
+actions = ["notify"]
+
+[alerts.bad_exit]
+condition = "container.exit_code != 0"
+for = "0s"
+severity = "warning"
+actions = ["notify"]
+
+# [alerts.error_spike]
+# condition = "log.count > 10"
+# match = "error"                    # substring match (case-insensitive)
+# window = "5m"
+# severity = "warning"
+# actions = ["notify"]
+
+# [alerts.oom_kills]
+# condition = "log.count > 0"
+# match = "\\bOOM\\b|\\bout of memory\\b"        # regex match
+# match_regex = true
+# window = "10m"
 # severity = "critical"
 # actions = ["notify"]
 

--- a/internal/agent/alert_test.go
+++ b/internal/agent/alert_test.go
@@ -1468,7 +1468,7 @@ func TestLogAlertRegexMatch(t *testing.T) {
 	alerts := map[string]AlertConfig{
 		"oom": {
 			Condition:  "log.count > 0",
-			Match:      "OOM|out of memory",
+			Match:      `\bOOM\b|\bout of memory\b`,
 			MatchRegex: true,
 			Window:     Duration{10 * time.Minute},
 			Severity:   "critical",
@@ -1485,6 +1485,7 @@ func TestLogAlertRegexMatch(t *testing.T) {
 		{Timestamp: now, ContainerID: "aaa", ContainerName: "web", Stream: "stderr", Message: "OOM killed process 1234"},
 		{Timestamp: now, ContainerID: "bbb", ContainerName: "api", Stream: "stderr", Message: "out of memory allocating 1MB"},
 		{Timestamp: now, ContainerID: "ccc", ContainerName: "db", Stream: "stdout", Message: "normal log line"},
+		{Timestamp: now, ContainerID: "ddd", ContainerName: "bloom", Stream: "stderr", Message: "container bloomoord started"},
 	})
 
 	a.Evaluate(ctx, &MetricSnapshot{
@@ -1492,6 +1493,7 @@ func TestLogAlertRegexMatch(t *testing.T) {
 			{ID: "aaa", Name: "web", State: "running"},
 			{ID: "bbb", Name: "api", State: "running"},
 			{ID: "ccc", Name: "db", State: "running"},
+			{ID: "ddd", Name: "bloom", State: "running"},
 		},
 	})
 
@@ -1502,7 +1504,10 @@ func TestLogAlertRegexMatch(t *testing.T) {
 		t.Error("expected oom:bbb firing")
 	}
 
-	// "ccc" has no matching logs.
+	// "ccc" has no matching logs, "ddd" has "oom" as substring — should not match.
+	if inst := a.instances["oom:ddd"]; inst != nil && inst.state == stateFiring {
+		t.Error("oom:ddd should not fire — 'bloomoord' contains 'oom' as substring, not word boundary")
+	}
 	var count int
 	if err := s.db.QueryRow("SELECT COUNT(*) FROM alerts").Scan(&count); err != nil {
 		t.Fatal(err)

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -716,7 +716,7 @@ func TestLoadConfigLogAlertRegex(t *testing.T) {
 	os.WriteFile(path, []byte(`
 [alerts.oom]
 condition = "log.count > 0"
-match = "OOM|out of memory"
+match = "\\bOOM\\b|\\bout of memory\\b"
 match_regex = true
 window = "10m"
 severity = "critical"


### PR DESCRIPTION
The default pattern "OOM|out of memory" matched substrings (e.g. "bloomoord"), causing false positives. Add \b word boundaries to both alternatives.

Also align install.sh default alert config with docker-compose.yml — bare metal installs now ship the same enabled alert rules as compose.